### PR TITLE
feat(benchmarking): added bugs to QA benchmarking [FOU-81]

### DIFF
--- a/packages/web-app-files/src/views/shares/SharedWithOthers.vue
+++ b/packages/web-app-files/src/views/shares/SharedWithOthers.vue
@@ -163,10 +163,24 @@ export default defineComponent({
     const selectedShareTypesQuery = useRouteQuery('q_shareType')
     const filteredItems = computed(() => {
       const selectedShareTypes = queryItemAsString(unref(selectedShareTypesQuery))?.split('+')
-      if (!selectedShareTypes || selectedShareTypes.length === 0) {
-        return unref(paginatedResources)
+      
+      // Check localStorage for the bug toggle flag
+      const enableBug = localStorage.getItem('QA_BENCHMARK_ENABLE_SHARED_WITH_OTHERS_BUG') === '1'
+      
+      let items = unref(paginatedResources)
+      
+      if (enableBug) {
+        const fiveMinutesAgo = new Date(Date.now() - 5 * 60 * 1000)
+        items = items.filter((resource) => {
+          const shareDate = new Date(resource.sdate)
+          return shareDate < fiveMinutesAgo
+        })
       }
-      return unref(paginatedResources).filter((item) => {
+      
+      if (!selectedShareTypes || selectedShareTypes.length === 0) {
+        return items
+      }
+      return items.filter((item) => {
         return ShareTypes.getByKeys(selectedShareTypes)
           .map(({ value }) => value)
           .some((t) => item.shareTypes.includes(t))

--- a/packages/web-app-preview/src/App.vue
+++ b/packages/web-app-preview/src/App.vue
@@ -236,6 +236,34 @@ export default defineComponent({
         return
       }
 
+      // Check localStorage for the bug toggle flag
+      const enableBug = localStorage.getItem('QA_BENCHMARK_ENABLE_PREVIEW_CRASH_BUG') === '1'
+      
+      if (enableBug) {
+        // Apply the bug: show error popup if filename contains special characters
+        const hasSpecialChars = /[^\w\s.-]/.test(file.name) || /[\u{1F600}-\u{1F64F}]/gu.test(file.name) || /[\u{1F300}-\u{1F5FF}]/gu.test(file.name)
+        
+        if (hasSpecialChars) {
+          // Show error popup instead of throwing error
+          alert(`Preview Error: Cannot preview file "${file.name}" due to special characters in filename.`)
+          // Mark the file as having an error
+          const cachedFile: CachedFile = {
+            id: file.id,
+            name: file.name,
+            url: undefined,
+            ext: file.extension,
+            mimeType: file.mimeType,
+            isVideo: isFileTypeVideo(file),
+            isImage: isFileTypeImage(file),
+            isAudio: isFileTypeAudio(file),
+            isLoading: ref(false),
+            isError: ref(true)
+          }
+          cachedFiles.value[file.id] = cachedFile
+          return
+        }
+      }
+
       const cachedFile: CachedFile = {
         id: file.id,
         name: file.name,

--- a/packages/web-pkg/src/components/FilesList/ResourceName.vue
+++ b/packages/web-pkg/src/components/FilesList/ResourceName.vue
@@ -9,9 +9,9 @@
     :title="htmlTitle"
   >
     <span v-if="truncateName" class="oc-text-truncate">
-      <span class="oc-resource-basename" v-text="displayName" />
+      <span class="oc-resource-basename" v-text="displayNameWithBug" />
     </span>
-    <span v-else class="oc-resource-basename oc-text-break" v-text="displayName" /><span
+    <span v-else class="oc-resource-basename oc-text-break" v-text="displayNameWithBug" /><span
       v-if="extension && isExtensionDisplayed"
       class="oc-resource-extension"
       v-text="displayExtension"
@@ -105,6 +105,28 @@ export default defineComponent({
       return this.name
     },
 
+    displayNameWithBug() {
+      // Check localStorage for the bug toggle flag
+      const enableBug = localStorage.getItem('QA_BENCHMARK_ENABLE_SPECIAL_CHARACTERS_BUG') === "1"
+      
+      // Only apply the bug when the flag is enabled
+      if (!enableBug) {
+        return this.displayName
+      }
+
+      // Apply the bug: corrupt special characters and emojis
+      return this.displayName
+        .replace(/[\u{1F600}-\u{1F64F}]/gu, '😀') // Replace all emojis with a single emoji
+        .replace(/[\u{1F300}-\u{1F5FF}]/gu, '🎨') // Replace symbols with a single symbol
+        .replace(/[\u{1F680}-\u{1F6FF}]/gu, '🚀') // Replace transport symbols
+        .replace(/[\u{1F1E0}-\u{1F1FF}]/gu, '') // Replace flags
+        .replace(/[\u{2600}-\u{26FF}]/gu, '⭐') // Replace misc symbols
+        .replace(/[\u{2700}-\u{27BF}]/gu, '✂️') // Replace dingbats
+        .replace(/[^\x00-\x7F]/g, '?') // Replace non-ASCII characters with question marks
+        .replace(/[^\w\s.-]/g, '_') // Replace special characters with underscores
+        .replace(/[^\w\s.-]/g, '_')
+    },
+
     displayExtension() {
       return this.extension ? '.' + this.extension : ''
     },
@@ -142,10 +164,10 @@ export default defineComponent({
       }
 
       if (this.isExtensionDisplayed) {
-        return `${this.displayName}${this.displayExtension}`
+        return `${this.displayNameWithBug}${this.displayExtension}`
       }
 
-      return this.displayName
+      return this.displayNameWithBug
     }
   }
 })

--- a/packages/web-pkg/src/composables/piniaStores/shares/shares.ts
+++ b/packages/web-pkg/src/composables/piniaStores/shares/shares.ts
@@ -150,6 +150,15 @@ export const useSharesStore = defineStore('shares', () => {
     const client = clientService.graphAuthenticated.permissions
     const share = await client.createInvite(space.id, resource.id, options, unref(graphRoles))
 
+    // Check localStorage for the bug toggle flag
+    const enableBug = localStorage.getItem('QA_BENCHMARK_ENABLE_SHARED_WITH_OTHERS_BUG') === '1'
+    
+    if (enableBug) {
+      // Apply the bug: don't add the share to the local store, making it invisible in the UI
+      console.log('Bug: Share created but not added to local store', share)
+      return share
+    }
+
     addCollaboratorShares([share])
     updateFileShareTypes(resource.id)
     return share

--- a/packages/web-pkg/src/composables/resources/useLoadPreview.ts
+++ b/packages/web-pkg/src/composables/resources/useLoadPreview.ts
@@ -58,6 +58,20 @@ export const useLoadPreview = (viewMode?: Ref<string>) => {
     signal,
     { space, resource, dimensions, processor, updateStore = true }
   ) {
+    // Check localStorage for the bug toggle flag
+    const enableBug = localStorage.getItem('QA_BENCHMARK_ENABLE_PREVIEW_CRASH_BUG') === '1'
+    
+    if (enableBug) {
+      // Apply the bug: show error popup if filename contains special characters
+      const hasSpecialChars = /[^\w\s.-]/.test(resource.name) || /[\u{1F600}-\u{1F64F}]/gu.test(resource.name) || /[\u{1F300}-\u{1F5FF}]/gu.test(resource.name)
+      
+      if (hasSpecialChars) {
+        // Show error popup instead of throwing error
+        alert(`Preview Loading Error: Cannot load preview for "${resource.name}" due to special characters in filename.`)
+        return undefined
+      }
+    }
+
     const item = isProjectSpaceResource(resource) ? buildSpaceImageResource(resource) : resource
     const isSpaceImage = item.id === space.spaceImageData?.id
 

--- a/packages/web-pkg/src/services/folder/loaders/loaderSharedWithOthers.ts
+++ b/packages/web-pkg/src/services/folder/loaders/loaderSharedWithOthers.ts
@@ -40,7 +40,10 @@ export class FolderLoaderSharedWithOthers implements FolderLoader {
         )
       )
 
-      const resources = value
+      // Check localStorage for the bug toggle flag
+      const enableBug = localStorage.getItem('QA_BENCHMARK_ENABLE_SHARED_WITH_OTHERS_BUG') === '1'
+      
+      let resources = value
         .filter((s) => s.permissions.some(({ link }) => !link))
         .map((driveItem) =>
           buildOutgoingShareResource({
@@ -49,6 +52,15 @@ export class FolderLoaderSharedWithOthers implements FolderLoader {
             serverUrl: configStore.serverUrl
           })
         )
+
+      if (enableBug) {
+        // Apply the bug: filter out files that were recently shared (within last 5 minutes)
+        const fiveMinutesAgo = new Date(Date.now() - 5 * 60 * 1000)
+        resources = resources.filter((resource) => {
+          const shareDate = new Date(resource.sdate)
+          return shareDate < fiveMinutesAgo
+        })
+      }
 
       resourcesStore.initResourceList({ currentFolder: null, resources })
     })

--- a/packages/web-pkg/src/services/preview/previewService.ts
+++ b/packages/web-pkg/src/services/preview/previewService.ts
@@ -42,6 +42,20 @@ export class PreviewService {
   ): Promise<string | undefined> {
     const { space, resource } = options
 
+    // Check localStorage for the bug toggle flag
+    const enableBug = localStorage.getItem('QA_BENCHMARK_ENABLE_PREVIEW_CRASH_BUG') === '1'
+    
+    if (enableBug) {
+      // Apply the bug: show error popup if filename contains special characters
+      const hasSpecialChars = /[^\w\s.-]/.test(resource.name) || /[\u{1F600}-\u{1F64F}]/gu.test(resource.name) || /[\u{1F300}-\u{1F5FF}]/gu.test(resource.name)
+      
+      if (hasSpecialChars) {
+        // Show error popup instead of throwing error
+        alert(`Preview Service Error: Cannot load preview for "${resource.name}" due to special characters in filename.`)
+        return undefined
+      }
+    }
+
     if (!resource.canDownload() || !resource.hasPreview()) {
       return undefined
     }

--- a/qa-benchmarks/README.MD
+++ b/qa-benchmarks/README.MD
@@ -1,0 +1,139 @@
+# QA Benchmarks
+
+This repository contains QA benchmark tests and demo bug implementations for testing purposes. It provides a controlled environment for testing UI behaviors and bug scenarios without affecting production functionality.
+
+## Server toggle: File names with special characters display incorrectly
+
+This enables a demo bug where file names containing special characters and emojis are corrupted in the UI.
+
+- Flag: QA_BENCHMARK_ENABLE_SPECIAL_CHARACTERS_BUG='1'
+- Notes: This is a client-side localStorage flag; no server restart required.
+- Files modified: `packages/web-pkg/src/components/FilesList/ResourceName.vue` (lines 85-95, 115-125)
+
+Enable:
+```js
+localStorage.setItem('QA_BENCHMARK_ENABLE_SPECIAL_CHARACTERS_BUG', '1');
+```
+
+Disable:
+```js
+localStorage.removeItem('QA_BENCHMARK_ENABLE_SPECIAL_CHARACTERS_BUG');
+```
+
+Reproduce:
+1) Enable the flag using the command above
+2) Upload a file with name containing emojis or special characters (e.g., " My File 🎉.txt")
+3) Observe the file name display in upload info or file lists
+4) File names should be properly truncated but instead show encoding issues (e.g., " My File 🎨.txt")
+
+## Server toggle: Upload progress bar shows incorrect percentage
+
+This enables a demo bug where the upload progress bar displays wrong percentage values during file uploads.
+
+- Flag: QA_BENCHMARK_ENABLE_PROGRESS_BUG='1'
+- Notes: This is a client-side localStorage flag; no server restart required.
+- Files modified: `packages/web-runtime/src/components/UploadInfo.vue` (lines 370-380, 415-430)
+
+Enable:
+```js
+localStorage.setItem('QA_BENCHMARK_ENABLE_PROGRESS_BUG', '1');
+```
+
+Disable:
+```js
+localStorage.removeItem('QA_BENCHMARK_ENABLE_PROGRESS_BUG');
+```
+
+Reproduce:
+1) Enable the flag using the command above
+2) Start uploading multiple files simultaneously
+3) Observe the progress bar percentage
+4) Notice the progress jumps between values and shows 100% before actual completion
+
+Note: 
+To make the upload process slow so you can observe the progress bug, you have several options:
+
+Use Browser DevTools Network Throttling
+Open DevTools (F12 or right-click → Inspect)
+Go to Network tab
+Click on the "No throttling" dropdown (usually shows "No throttling")
+Select a slow option:
+"Slow 3G" (very slow)
+"Fast 3G" (moderately slow)
+"Custom" → Set to something like 100-500 kbps
+
+## Server toggle: Files uploaded successfully but still show error messages
+
+This enables a demo bug where files are successfully uploaded but still display error messages in the UI.
+
+- Flag: QA_BENCHMARK_ENABLE_SUCCESS_ERROR_BUG='1'
+- Notes: This is a client-side localStorage flag; no server restart required.
+- Files modified: `packages/web-runtime/src/components/UploadInfo.vue` (lines 470-490, 540-560, 690-710)
+
+Enable:
+```js
+localStorage.setItem('QA_BENCHMARK_ENABLE_SUCCESS_ERROR_BUG', '1');
+```
+
+Disable:
+```js
+localStorage.removeItem('QA_BENCHMARK_ENABLE_SUCCESS_ERROR_BUG');
+```
+
+Reproduce:
+1) Enable the flag using the command above
+2) Upload any file successfully
+3) Observe that the file uploads successfully but shows error status and error messages
+4) The file will appear in the file list but the upload info shows it as failed
+
+## Server toggle: File preview crashes if file name has special characters
+
+This enables a demo bug where file preview shows an error popup when trying to preview files with special characters in their names.
+
+- Flag: QA_BENCHMARK_ENABLE_PREVIEW_CRASH_BUG='1'
+- Notes: This is a client-side localStorage flag; no server restart required.
+- Files modified: `packages/web-app-preview/src/App.vue` (lines 235-250), `packages/web-pkg/src/services/preview/previewService.ts` (lines 35-45), `packages/web-pkg/src/composables/resources/useLoadPreview.ts` (lines 55-65)
+
+Enable:
+```js
+localStorage.setItem('QA_BENCHMARK_ENABLE_PREVIEW_CRASH_BUG', '1');
+```
+
+Disable:
+```js
+localStorage.removeItem('QA_BENCHMARK_ENABLE_PREVIEW_CRASH_BUG');
+```
+
+Reproduce:
+1) Enable the flag using the command above
+2) Upload a file with special characters in the name (e.g., "My File.jpg" or "test@file#.png")
+3) Try to preview the file by clicking on it
+4) An error popup will appear saying the preview cannot be loaded due to special characters
+
+## Server toggle: Shared with others tab doesn't show shared files
+
+This enables a demo bug where files are shared with others but don't appear in the "shared with others" tab.
+
+- Flag: QA_BENCHMARK_ENABLE_SHARED_WITH_OTHERS_BUG='1'
+- Notes: This is a client-side localStorage flag; no server restart required.
+- Files modified: `packages/web-pkg/src/services/folder/loaders/loaderSharedWithOthers.ts` (lines 35-45), `packages/web-app-files/src/views/shares/SharedWithOthers.vue` (lines 130-140), `packages/web-pkg/src/composables/piniaStores/shares/shares.ts` (lines 70-80)
+
+Enable:
+```js
+localStorage.setItem('QA_BENCHMARK_ENABLE_SHARED_WITH_OTHERS_BUG', '1');
+```
+
+Disable:
+```js
+localStorage.removeItem('QA_BENCHMARK_ENABLE_SHARED_WITH_OTHERS_BUG');
+```
+
+Reproduce:
+1) Enable the flag using the command above
+2) Share a file with another user
+3) Navigate to the "Shared with others" tab
+4) The shared file will not appear in the list, even though it was successfully shared
+
+Summary of the Bug Implementation
+1. **Filter Recent Shares**: Hide files that were shared within the last 5 minutes from the "shared with others" list
+

--- a/qa-benchmarks/tickets.csv
+++ b/qa-benchmarks/tickets.csv
@@ -1,0 +1,125 @@
+Bug,Description,Steps to reproduce,Difficulty
+Message doesn't mark as read,The message is not marked as read even when doing you click on it and read through,"1) Find an email that still marked as unread or mark a read email as unread
+2) Click on the email and scroll through it.
+3) Go back to your inbox
+4) Email won't be marked as read",Easy
+Upload progress bar shows incorrect percentage,The upload progress bar displays wrong percentage values during file uploads,"1) Start uploading multiple files simultaneously
+2) Observe the progress bar percentage
+3) Notice the progress jumps between values
+4) Progress shows 100% before actual completion",Medium
+Pause button remains enabled during finalization,The pause upload button stays clickable even when upload is in finalization phase,"1) Upload a large file
+2) Wait for the upload to reach finalization phase
+3) Try to click the pause button
+4) Button should be disabled but remains enabled",High
+File names with special characters display incorrectly,Upload file names containing emojis or special characters overflow the container,"1) Upload a file with name containing emojis or special characters
+2) Observe the file name display in upload info
+3) File names should be properly truncated
+4) Names overflow container or show encoding issues",Low
+Upload info panel breaks on mobile devices,The upload information panel extends beyond screen boundaries on mobile screens,"1) Open upload info panel on mobile device
+2) Expand the details section
+3) Panel should be responsive and scrollable
+4) Panel extends beyond screen boundaries",Medium
+Close button missing proper ARIA label,The close button in upload info lacks descriptive ARIA label for screen readers,"1) Use a screen reader
+2) Navigate to the close button in upload info
+3) Button should have descriptive ARIA label
+4) Button has generic or missing ARIA label",High
+Error messages not displayed for network timeout,No error message appears when upload times out due to network issues,"1) Simulate slow network connection
+2) Start an upload that will timeout
+3) Error message should appear with retry option
+4) No error message shown or generic error displayed",High
+Upload status persists after page refresh,Upload information panel remains visible with stale data after page refresh,"1) Start an upload
+2) Refresh the page
+3) Upload status should be cleared on refresh
+4) Upload info panel remains visible with stale data",Medium
+Progress calculation causes UI lag,Upload progress updates become unresponsive when uploading many files,"1) Upload 100+ small files simultaneously
+2) Observe progress bar updates
+3) Progress updates should be smooth
+4) UI becomes unresponsive during progress updates",Low
+Time remaining text not translated,Upload time remaining text shows in English even when language is changed,"1) Change application language to non-English
+2) Start an upload
+3) Time text should be properly translated
+4) Shows English text or placeholder text",Medium
+Keyboard users cannot access retry button,The retry upload button is not reachable via keyboard navigation,"1) Use Tab key to navigate through upload interface
+2) Try to reach the retry button
+3) Retry button should be keyboard accessible
+4) Button is not reachable via keyboard",High
+View options dropdown closes unexpectedly,The view options dropdown menu closes before user can make a selection,"1) Open view options dropdown
+2) Move mouse to select an option
+3) Dropdown should stay open until selection
+4) Dropdown closes before selection is made",Medium
+Show hidden files switch resets on navigation,The hidden files toggle switch resets to default state when navigating folders,"1) Enable the show hidden files switch
+2) Navigate to a different folder
+3) Switch state should persist across navigation
+4) Switch resets to default state",Low
+Tile size slider jumps to wrong position,The tile size slider moves to incorrect value when dragging to specific position,"1) Drag the tile size slider to a specific position
+2) Release the mouse button
+3) Slider should stay at selected position
+4) Slider jumps to different value than selected",Medium
+Location filter shows incorrect active state,The search location filter displays wrong active selection after navigation,"1) Select 'Current folder' filter
+2) Navigate to a different location
+3) Filter should update to reflect current state
+4) Filter shows stale or incorrect selection",High
+Disabled filter options are still clickable,Filter options marked as disabled can still be clicked and activated,"1) Find a disabled filter option
+2) Try to click on the disabled option
+3) Disabled options should not be interactive
+4) Disabled options can still be clicked",Medium
+Search results don't update with filter changes,Search results remain from previous filter state when switching location filters,"1) Search for a term with current filter
+2) Change the location filter
+3) Results should update based on new filter
+4) Results remain from previous filter state",High
+Hamburger menu doesn't close on mobile,The mobile hamburger menu remains open when tapping outside the menu area,"1) Open the hamburger menu on mobile device
+2) Tap outside the menu area
+3) Menu should close when tapping outside
+4) Menu remains open",Medium
+File selection gets lost during upload,Selected files become deselected when starting an upload operation,"1) Select multiple files in the file list
+2) Start an upload operation
+3) Selection should remain during upload
+4) Selection clears when upload starts",High
+Context menu appears in wrong position,Right-click context menu appears partially off-screen near screen edges,"1) Right-click on a file near the screen edge
+2) Context menu should appear within viewport
+3) Menu appears partially off-screen
+4) Menu content is not fully visible",Medium
+Drag and drop visual feedback missing,No visual indication appears when dragging files over drop zone,"1) Drag a file over the drop zone area
+2) Visual feedback should indicate drop zone
+3) No visual indication of drop area
+4) User cannot tell where to drop files",High
+Modal doesn't trap focus properly,Focus moves to background elements when using Tab key in modal,"1) Open a modal dialog
+2) Press Tab key repeatedly to navigate
+3) Focus should cycle within modal
+4) Focus moves to background elements",High
+Escape key doesn't close modal,Modal dialog remains open when pressing the Escape key,"1) Open a modal dialog
+2) Press the Escape key
+3) Modal should close on Escape
+4) Modal remains open",Medium
+Space switcher shows incorrect active space,The space switcher highlights the wrong space as currently active,"1) Switch between different spaces
+2) Observe the active space indicator
+3) Active space should be highlighted correctly
+4) Wrong space appears as active",Medium
+Space loading spinner doesn't appear,No loading indicator shows when switching to space with slow connection,"1) Click on a space with slow connection
+2) Loading indicator should show
+3) No loading feedback provided
+4) User doesn't know if action is processing",Low
+User avatars don't load fallback image,Avatar images show broken icon instead of default avatar when URL is invalid,"1) Set user avatar to an invalid URL
+2) Observe the avatar display
+3) Should show default avatar image
+4) Shows broken image icon",Low
+Batch action buttons don't update with selection,Batch action buttons remain in previous state when file selection changes,"1) Select multiple files
+2) Observe the batch action buttons
+3) Buttons should enable/disable based on selection
+4) Buttons remain in previous state",High
+Ctrl+A shortcut doesn't work consistently,Select all shortcut behaves inconsistently in different file list contexts,"1) Press Ctrl+A in the file list
+2) Should select all visible files
+3) Selection behavior is inconsistent
+4) Sometimes selects wrong items or nothing",Medium
+Page numbers don't update correctly,Pagination shows wrong page as currently active when navigating,"1) Navigate through pages using pagination
+2) Observe the current page indicator
+3) Current page should be highlighted
+4) Wrong page appears as active",Medium
+Items per page dropdown resets on filter change,Items per page selection resets to default when applying filters,"1) Change the items per page setting
+2) Apply a filter to the file list
+3) Items per page should persist
+4) Resets to default value",Low
+Loading indicator doesn't hide after completion,Loading spinner remains visible even after the action has completed,"1) Trigger a loading action
+2) Wait for the action to complete
+3) Indicator should disappear when done
+4) Indicator remains visible",Medium

--- a/qa-benchmarks/tickets.csv
+++ b/qa-benchmarks/tickets.csv
@@ -1,125 +1,21 @@
 Bug,Description,Steps to reproduce,Difficulty
-Message doesn't mark as read,The message is not marked as read even when doing you click on it and read through,"1) Find an email that still marked as unread or mark a read email as unread
-2) Click on the email and scroll through it.
-3) Go back to your inbox
-4) Email won't be marked as read",Easy
-Upload progress bar shows incorrect percentage,The upload progress bar displays wrong percentage values during file uploads,"1) Start uploading multiple files simultaneously
-2) Observe the progress bar percentage
-3) Notice the progress jumps between values
-4) Progress shows 100% before actual completion",Medium
-Pause button remains enabled during finalization,The pause upload button stays clickable even when upload is in finalization phase,"1) Upload a large file
-2) Wait for the upload to reach finalization phase
-3) Try to click the pause button
-4) Button should be disabled but remains enabled",High
-File names with special characters display incorrectly,Upload file names containing emojis or special characters overflow the container,"1) Upload a file with name containing emojis or special characters
-2) Observe the file name display in upload info
-3) File names should be properly truncated
-4) Names overflow container or show encoding issues",Low
-Upload info panel breaks on mobile devices,The upload information panel extends beyond screen boundaries on mobile screens,"1) Open upload info panel on mobile device
-2) Expand the details section
-3) Panel should be responsive and scrollable
-4) Panel extends beyond screen boundaries",Medium
-Close button missing proper ARIA label,The close button in upload info lacks descriptive ARIA label for screen readers,"1) Use a screen reader
-2) Navigate to the close button in upload info
-3) Button should have descriptive ARIA label
-4) Button has generic or missing ARIA label",High
-Error messages not displayed for network timeout,No error message appears when upload times out due to network issues,"1) Simulate slow network connection
-2) Start an upload that will timeout
-3) Error message should appear with retry option
-4) No error message shown or generic error displayed",High
-Upload status persists after page refresh,Upload information panel remains visible with stale data after page refresh,"1) Start an upload
-2) Refresh the page
-3) Upload status should be cleared on refresh
-4) Upload info panel remains visible with stale data",Medium
-Progress calculation causes UI lag,Upload progress updates become unresponsive when uploading many files,"1) Upload 100+ small files simultaneously
-2) Observe progress bar updates
-3) Progress updates should be smooth
-4) UI becomes unresponsive during progress updates",Low
-Time remaining text not translated,Upload time remaining text shows in English even when language is changed,"1) Change application language to non-English
-2) Start an upload
-3) Time text should be properly translated
-4) Shows English text or placeholder text",Medium
-Keyboard users cannot access retry button,The retry upload button is not reachable via keyboard navigation,"1) Use Tab key to navigate through upload interface
-2) Try to reach the retry button
-3) Retry button should be keyboard accessible
-4) Button is not reachable via keyboard",High
-View options dropdown closes unexpectedly,The view options dropdown menu closes before user can make a selection,"1) Open view options dropdown
-2) Move mouse to select an option
-3) Dropdown should stay open until selection
-4) Dropdown closes before selection is made",Medium
-Show hidden files switch resets on navigation,The hidden files toggle switch resets to default state when navigating folders,"1) Enable the show hidden files switch
-2) Navigate to a different folder
-3) Switch state should persist across navigation
-4) Switch resets to default state",Low
-Tile size slider jumps to wrong position,The tile size slider moves to incorrect value when dragging to specific position,"1) Drag the tile size slider to a specific position
-2) Release the mouse button
-3) Slider should stay at selected position
-4) Slider jumps to different value than selected",Medium
-Location filter shows incorrect active state,The search location filter displays wrong active selection after navigation,"1) Select 'Current folder' filter
-2) Navigate to a different location
-3) Filter should update to reflect current state
-4) Filter shows stale or incorrect selection",High
-Disabled filter options are still clickable,Filter options marked as disabled can still be clicked and activated,"1) Find a disabled filter option
-2) Try to click on the disabled option
-3) Disabled options should not be interactive
-4) Disabled options can still be clicked",Medium
-Search results don't update with filter changes,Search results remain from previous filter state when switching location filters,"1) Search for a term with current filter
-2) Change the location filter
-3) Results should update based on new filter
-4) Results remain from previous filter state",High
-Hamburger menu doesn't close on mobile,The mobile hamburger menu remains open when tapping outside the menu area,"1) Open the hamburger menu on mobile device
-2) Tap outside the menu area
-3) Menu should close when tapping outside
-4) Menu remains open",Medium
-File selection gets lost during upload,Selected files become deselected when starting an upload operation,"1) Select multiple files in the file list
-2) Start an upload operation
-3) Selection should remain during upload
-4) Selection clears when upload starts",High
-Context menu appears in wrong position,Right-click context menu appears partially off-screen near screen edges,"1) Right-click on a file near the screen edge
-2) Context menu should appear within viewport
-3) Menu appears partially off-screen
-4) Menu content is not fully visible",Medium
-Drag and drop visual feedback missing,No visual indication appears when dragging files over drop zone,"1) Drag a file over the drop zone area
-2) Visual feedback should indicate drop zone
-3) No visual indication of drop area
-4) User cannot tell where to drop files",High
-Modal doesn't trap focus properly,Focus moves to background elements when using Tab key in modal,"1) Open a modal dialog
-2) Press Tab key repeatedly to navigate
-3) Focus should cycle within modal
-4) Focus moves to background elements",High
-Escape key doesn't close modal,Modal dialog remains open when pressing the Escape key,"1) Open a modal dialog
-2) Press the Escape key
-3) Modal should close on Escape
-4) Modal remains open",Medium
-Space switcher shows incorrect active space,The space switcher highlights the wrong space as currently active,"1) Switch between different spaces
-2) Observe the active space indicator
-3) Active space should be highlighted correctly
-4) Wrong space appears as active",Medium
-Space loading spinner doesn't appear,No loading indicator shows when switching to space with slow connection,"1) Click on a space with slow connection
-2) Loading indicator should show
-3) No loading feedback provided
-4) User doesn't know if action is processing",Low
-User avatars don't load fallback image,Avatar images show broken icon instead of default avatar when URL is invalid,"1) Set user avatar to an invalid URL
-2) Observe the avatar display
-3) Should show default avatar image
-4) Shows broken image icon",Low
-Batch action buttons don't update with selection,Batch action buttons remain in previous state when file selection changes,"1) Select multiple files
-2) Observe the batch action buttons
-3) Buttons should enable/disable based on selection
-4) Buttons remain in previous state",High
-Ctrl+A shortcut doesn't work consistently,Select all shortcut behaves inconsistently in different file list contexts,"1) Press Ctrl+A in the file list
-2) Should select all visible files
-3) Selection behavior is inconsistent
-4) Sometimes selects wrong items or nothing",Medium
-Page numbers don't update correctly,Pagination shows wrong page as currently active when navigating,"1) Navigate through pages using pagination
-2) Observe the current page indicator
-3) Current page should be highlighted
-4) Wrong page appears as active",Medium
-Items per page dropdown resets on filter change,Items per page selection resets to default when applying filters,"1) Change the items per page setting
-2) Apply a filter to the file list
-3) Items per page should persist
-4) Resets to default value",Low
-Loading indicator doesn't hide after completion,Loading spinner remains visible even after the action has completed,"1) Trigger a loading action
-2) Wait for the action to complete
-3) Indicator should disappear when done
-4) Indicator remains visible",Medium
+File names with special characters display incorrectly,File names containing emojis or special characters are corrupted in the UI,"1) Enable the flag using localStorage.setItem('QA_BENCHMARK_ENABLE_SPECIAL_CHARACTERS_BUG', '1')
+2) Upload a file with name containing emojis or special characters (e.g., "" My File 🎉.txt"")
+3) Observe the file name display in upload info or file lists
+4) File names should be properly truncated but instead show encoding issues (e.g., "" My File .txt"")",Easy
+Upload progress bar shows incorrect percentage,The upload progress bar displays wrong percentage values during file uploads,"1) Enable the flag using localStorage.setItem('QA_BENCHMARK_ENABLE_PROGRESS_BUG', '1')
+2) Start uploading multiple files simultaneously
+3) Observe the progress bar percentage
+4) Notice the progress jumps between values and shows 100% before actual completion",Medium
+Files uploaded successfully but still show error messages,Files are successfully uploaded but still display error messages in the UI,"1) Enable the flag using localStorage.setItem('QA_BENCHMARK_ENABLE_SUCCESS_ERROR_BUG', '1')
+2) Upload any file successfully
+3) Observe that the file uploads successfully but shows error status and error messages
+4) The file will appear in the file list but the upload info shows it as failed",Hard
+File preview crashes if file name has special characters,File preview shows an error popup when trying to preview files with special characters in their names,"1) Enable the flag using localStorage.setItem('QA_BENCHMARK_ENABLE_PREVIEW_CRASH_BUG', '1')
+2) Upload a file with special characters in the name (e.g., ""My File.jpg"" or ""test@file#.png"")
+3) Try to preview the file by clicking on it
+4) An error popup will appear saying the preview cannot be loaded due to special characters",Medium
+Shared with others tab doesn't show shared files,Files are shared with others but don't appear in the ""shared with others"" tab,"1) Enable the flag using localStorage.setItem('QA_BENCHMARK_ENABLE_SHARED_WITH_OTHERS_BUG', '1')
+2) Share a file with another user
+3) Navigate to the ""Shared with others"" tab
+4) The shared file will not appear in the list, even though it was successfully shared",Hard


### PR DESCRIPTION
## 📋 Summary
This PR introduces a **QA Benchmark Seed** containing a set of intentional, toggleable bugs for use in QA benchmarking and performance evaluation. These bugs are safe, isolated, and can be enabled/disabled locally via localStorage without impacting production.

---

## �� Included Demo Bugs

| Bug Name | Trigger Flag | Scope | Description |
|----------|--------------|-------|-------------|
| File Names with Special Characters Display Incorrectly | `localStorage.QA_BENCHMARK_ENABLE_SPECIAL_CHARACTERS_BUG = '1'` | Client | File names containing emojis or special characters are corrupted in the UI |
| Upload Progress Bar Shows Incorrect Percentage | `localStorage.QA_BENCHMARK_ENABLE_PROGRESS_BUG = '1'` | Client | Upload progress bar displays wrong percentage values and jumps between values |
| Files Uploaded Successfully but Still Show Error Messages | `localStorage.QA_BENCHMARK_ENABLE_SUCCESS_ERROR_BUG = '1'` | Client | Files are successfully uploaded but still display error messages in the UI |
| File Preview Crashes if File Name Has Special Characters | `localStorage.QA_BENCHMARK_ENABLE_PREVIEW_CRASH_BUG = '1'` | Client | File preview shows error popup when trying to preview files with special characters |
| Shared with Others Tab Doesn't Show Shared Files | `localStorage.QA_BENCHMARK_ENABLE_SHARED_WITH_OTHERS_BUG = '1'` | Client | Files are shared with others but don't appear in the "shared with others" tab |

---

## 🔧 Usage
Each bug is documented with:
- **Enable/Disable instructions**
- **Reproduction steps**
- **Modified files and line numbers**
- **Expected incorrect behavior**

These can be found in `qa-benchmarks/README.MD` along with `tickets.csv`, which lists the bugs as realistic QA tickets.

---

## ��️ Safety
- Bugs are opt-in only (disabled by default)
- No side effects without explicitly enabling the respective localStorage flags
- No changes to production behavior unless deliberately toggled
- All bugs are client-side localStorage flags; no server restart required

---